### PR TITLE
Use GITHUB_TOKEN in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-shared-activity-history-test
+        run: docker compose build hackney-shared-activity-history-test
       - name: Run tests
-        run: docker-compose run hackney-shared-activity-history-test
+        run: docker compose run hackney-shared-activity-history-test
         
   publish-package:
     name: Publish Package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -35,8 +33,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{ secrets.LBHPACKAGESTOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -50,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -66,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
       VERSION: ${{ needs.build-and-test.outputs.version }}
     steps:
       - name: Checkout
@@ -76,4 +72,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Shared.ActivityHistory/bin/Release
-          dotnet nuget push Hackney.Shared.ActivityHistory.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{ secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Shared.ActivityHistory.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/Hackney.Shared.ActivityHistory.Tests/Dockerfile
+++ b/Hackney.Shared.ActivityHistory.Tests/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,8 +11,16 @@ COPY ./Hackney.Shared.ActivityHistory/Hackney.Shared.ActivityHistory.csproj ./Ha
 COPY ./Hackney.Shared.ActivityHistory.Tests/Hackney.Shared.ActivityHistory.Tests.csproj ./Hackney.Shared.ActivityHistory.Tests/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Shared.ActivityHistory/Hackney.Shared.ActivityHistory.csproj
-RUN dotnet restore ./Hackney.Shared.ActivityHistory.Tests/Hackney.Shared.ActivityHistory.Tests.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Shared.ActivityHistory/Hackney.Shared.ActivityHistory.csproj && \
+  dotnet restore ./Hackney.Shared.ActivityHistory.Tests/Hackney.Shared.ActivityHistory.Tests.csproj
 
 # Copy everything else and build
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,12 @@ services:
     build:
       context: .
       dockerfile: Hackney.Shared.ActivityHistory.Tests/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
+
+# see https://docs.docker.com/compose/how-tos/use-secrets/#build-secrets
+# Combines with a "secrets" block in each service to expose it as a file in
+# /run/secrets/, e.g. /run/secrets/LBHPACKAGESTOKEN
+secrets:
+  LBHPACKAGESTOKEN:
+    environment: LBHPACKAGESTOKEN


### PR DESCRIPTION
This change removes two environment variables from CI which have been used to carry credentials to publish/read packages to our GitHub Packages NuGet registry:

- `LBHPACKAGESTOKEN`
- `NUGET_KEY`

`LBHPACKAGESTOKEN` continues to be used for local development.

#### What is the problem we're trying to solve?

Historically we've published packages from our local machines, which requires a token to authenticate with the GitHub Packages NuGet Registry. Now we use CI to publish packages there is a GitHub-managed token we can use instead..

> If you're using a registry that supports granular permissions, and your workflow is using a personal access token to authenticate to the registry, then we highly recommend you update your workflow to use the GITHUB_TOKEN.
>  ~ from https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-with-granular-permissions

This change removes both `LBHPACKAGESTOKEN` and `NUGET_KEY` tokens from the GitHub Actions workflow, replacing them where needed with the managed `GITHUB_TOKEN` token that's automatically made available to all jobs.

In order to keep the local development/management experience the same, references to `LBHPACKAGESTOKEN` have been kept as-is in the Docker and Docker Compose setup.

#### Additional improvement to Docker/Docker Compose secrets

Docker's documentation [suggests](https://docs.docker.com/reference/dockerfile/#arg) not to use build arguments to pass secrets, so this PR also updates the `Dockerfile` to use [secret mounts](https://docs.docker.com/build/building/secrets/#secret-mounts), and the recommended way to [manage secrets in docker compose](https://docs.docker.com/compose/how-tos/use-secrets/).

#### How to review this change

This change mirrors a couple we've already reviewed:

- https://github.com/LBHackney-IT/lbh-core/pull/64
- https://github.com/LBHackney-IT/housing-search-shared/pull/83

#### Checklist

- [x] Code pipeline builds correctly

### Follow up actions after merging PR

- [x] Remove this repo from the shared secrets listed above in GitHub Actions
